### PR TITLE
Fix authentication token expiry typing and cleanup lint errors

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,9 +1,13 @@
 import { Navigate, Outlet } from "react-router-dom";
 import { jwtDecode } from "jwt-decode";
 
+interface DecodedToken {
+  exp?: number;
+}
+
 const isTokenExpired = (token: string) => {
   try {
-    const decoded: any = jwtDecode(token);
+    const decoded = jwtDecode<DecodedToken>(token);
     if (!decoded.exp) return true;
     return Date.now() >= decoded.exp * 1000;
   } catch {

--- a/src/components/ecommerce/CountryMap.tsx
+++ b/src/components/ecommerce/CountryMap.tsx
@@ -8,16 +8,18 @@ interface CountryMapProps {
 }
 
 const CountryMap: React.FC<CountryMapProps> = ({ mapColor }) => {
+  const markerStyle: { initial: { fill: string; r: number } } = {
+    initial: {
+      fill: "#465FFF",
+      r: 4, // Custom radius for markers
+    },
+  };
+
   return (
     <VectorMap
       map={worldMill}
       backgroundColor="transparent"
-      markerStyle={{
-        initial: {
-          fill: "#465FFF",
-          r: 4, // Custom radius for markers
-        } as any, // Type assertion to bypass strict CSS property checks
-      }}
+      markerStyle={markerStyle}
       markersSelectable={true}
       markers={[
         {

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -3,7 +3,12 @@ import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import interactionPlugin from "@fullcalendar/interaction";
-import { EventInput, DateSelectArg, EventClickArg } from "@fullcalendar/core";
+import {
+  EventInput,
+  DateSelectArg,
+  EventClickArg,
+  EventContentArg,
+} from "@fullcalendar/core";
 import { Modal } from "../components/ui/modal";
 import { useModal } from "../hooks/useModal";
 import PageMeta from "../components/common/PageMeta";
@@ -268,7 +273,7 @@ const Calendar: React.FC = () => {
   );
 };
 
-const renderEventContent = (eventInfo: any) => {
+const renderEventContent = (eventInfo: EventContentArg) => {
   const colorClass = `fc-bg-${eventInfo.event.extendedProps.calendar.toLowerCase()}`;
   return (
     <div

--- a/src/pages/FileUploader.tsx
+++ b/src/pages/FileUploader.tsx
@@ -8,6 +8,10 @@ import "react-circular-progressbar/dist/styles.css";
 
 type Category = { label: string; value: string };
 
+interface CategoryResponse {
+  CategoryName: string;
+}
+
 
 
 
@@ -47,19 +51,17 @@ const FileUploader: React.FC = () => {
   useEffect(() => {
     const token = localStorage.getItem("token");
     fetch(`${API_URL}/api/categories`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  })
-    .then(res => res.json())
-    .then(data =>  setCategories(data.map(
-      (c: any) => ({ label: c.CategoryName, value: c.CategoryName })
-    )));
-}, []);
-
-useEffect(() => {
-  console.log("categories UPDATED:", categories);
-}, [categories]);
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+      .then((res) => res.json())
+      .then((data: CategoryResponse[]) =>
+        setCategories(
+          data.map((c) => ({ label: c.CategoryName, value: c.CategoryName }))
+        )
+      );
+  }, []);
   
 
   // Файл нэмэх
@@ -118,26 +120,26 @@ useEffect(() => {
       const formData = new FormData();
       formData.append("file", fileObj.file);
       fileObj.categories.forEach(cat => formData.append("categories[]", cat.value));
-      try {
-        await axios.post(`${API_URL}/api/files/upload`, formData, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-          onUploadProgress: progressEvent => {
-            const percent = Math.round(
-              (progressEvent.loaded * 100) / (progressEvent.total || 1)
-            );
-            setProgresses(prev => {
-              const copy = [...prev];
-              copy[idx] = percent;
-              return copy;
-            });
-          },
-        });
-        newResults[idx] = "✅ Амжилттай";
-      } catch (e) {
-        newResults[idx] = "❌ Алдаа";
-      }
+        try {
+          await axios.post(`${API_URL}/api/files/upload`, formData, {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+            onUploadProgress: (progressEvent) => {
+              const percent = Math.round(
+                (progressEvent.loaded * 100) / (progressEvent.total || 1)
+              );
+              setProgresses((prev) => {
+                const copy = [...prev];
+                copy[idx] = percent;
+                return copy;
+              });
+            },
+          });
+          newResults[idx] = "✅ Амжилттай";
+        } catch {
+          newResults[idx] = "❌ Алдаа";
+        }
     }
     setUploading(false);
     setUploadResults(newResults);

--- a/src/svg.d.ts
+++ b/src/svg.d.ts
@@ -1,5 +1,5 @@
 declare module "*.svg?react" {
-  import React = require("react");
+  import * as React from "react";
   export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
   const src: string;
   export default src;


### PR DESCRIPTION
## Summary
- replace `any` decoding in ProtectedRoute with typed JWT payload
- remove `any` casts in CountryMap and Calendar
- type category fetch and simplify error handling in FileUploader
- switch SVG module declaration to ES module import

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68995c0dd88c83239ea38dd990fd4004